### PR TITLE
Add syntax example for versions with lts inside README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [action.yml](action.yml)
   with:
     # Version Spec of the version to use in SemVer notation.
     # It also emits such aliases as lts, latest, nightly and canary builds
-    # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, 16-nightly, latest, node
+    # Examples: 12.x, 10.15.1, >=10.15.0, lts/Hydrogen, lts/*, 16-nightly, latest, node
     node-version: ''
 
     # File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.


### PR DESCRIPTION
**Description:**
As per issue linked below, this PR is supposed to add to the documentation an example syntax for using `lts` in `node-versions`.

**Related issue:** https://github.com/actions/setup-node/issues/761

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.